### PR TITLE
Add todo test for disconnected SQL generation

### DIFF
--- a/t/disconnected.t
+++ b/t/disconnected.t
@@ -1,0 +1,16 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use DBIx::Lite;
+
+my $dbix = DBIx::Lite->new;
+my ($sql) = eval { $dbix->table('authors')->select('id')->select_sql };
+{ local $TODO = 'disconnected SQL generation currently broken';
+ok !$@, 'no exception thrown';
+is $sql, 'SELECT me.id FROM authors AS me';
+}
+
+__END__


### PR DESCRIPTION
I added a test for #11 and marked it TODO so that it won’t fail. This way you can merge the PR and close it right away, without also having to fix the issue immediately.
